### PR TITLE
Moved sleep into main loop

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -183,9 +183,9 @@ void *obs_hadowplay_update(void *param)
 						recording_target_name.array);
 				}
 			}
-
-			os_sleep_ms(1000);
 		}
+
+		os_sleep_ms(1000);
 	}
 
 	obs_hadowplay_replay_buffer_stop();


### PR DESCRIPTION
Fixes a spike in cpu usage when disabling the auto replay buffer