### PR TITLE
Fix exclusions for compatibility with the new NVIDIA App

### DIFF
--- a/src/plugin-windows.cpp
+++ b/src/plugin-windows.cpp
@@ -175,6 +175,7 @@ static const char *exclusions[] = {
 	"obs",
 	"TextInputHost",
 	"NVIDIA Share",
+	"NVIDIA Overlay",
 	NULL,
 };
 


### PR DESCRIPTION
Add `NVIDIA Overlay` to the default exclusions to accommodate the new NVIDIA App.

Resolves https://github.com/EZ64cool/obs-hadowplay/issues/21.