### PR TITLE
Version 2.0.0 rewrite

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1,6 +1,6 @@
 /*
-Plugin Name
-Copyright (C) <Year> <Developer> <Email Address>
+obs-hadowplay
+Copyright (C) 2023 EZ64cool
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -36,7 +36,6 @@ OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
 bool obs_hadowplay_is_capture_source(obs_source_t *source)
 {
-	obs_log(LOG_INFO, "Source id %s", obs_source_get_id(source));
 	return (source != nullptr &&
 		(strcmpi(obs_source_get_id(source), "game_capture") == 0 ||
 		 strcmpi(obs_source_get_id(source), "window_capture") == 0));
@@ -49,13 +48,20 @@ bool obs_hadowplay_is_capture_source_hooked(obs_source_t *source)
 
 	proc_handler_t *source_proc_handler =
 		obs_source_get_proc_handler(source);
-	proc_handler_call(source_proc_handler, "get_hooked",
-				&hooked_calldata);
+	proc_handler_call(source_proc_handler, "get_hooked", &hooked_calldata);
 
-	const bool hooked = calldata_bool(&hooked_calldata, "hooked");
+	bool hooked = calldata_bool(&hooked_calldata, "hooked");
 	const char *exe = calldata_string(&hooked_calldata, "executable");
+	hooked &= obs_hadowplay_is_exe_excluded(exe) == false;
+	// Check for width & height, as window captures can stay hooked when hidden
+	if (hooked) {
+		hooked &= (obs_source_get_width(source) != 0 &&
+			   obs_source_get_height(source) != 0);
+	}
 
-	return hooked && obs_hadowplay_is_exe_excluded(exe);
+	calldata_free(&hooked_calldata);
+
+	return hooked;
 }
 
 void obs_hadowplay_enum_source_for_hooked_capture(obs_source_t *parent,
@@ -67,39 +73,168 @@ void obs_hadowplay_enum_source_for_hooked_capture(obs_source_t *parent,
 	obs_source_t **active_game_capture =
 		reinterpret_cast<obs_source_t **>(param);
 
-	if (*active_game_capture != NULL)
+	if (*active_game_capture != nullptr)
 		return;
 
-	if (obs_hadowplay_is_capture_source(source) && obs_hadowplay_is_capture_source_hooked(source)) {
+	if (obs_hadowplay_is_capture_source(source) &&
+	    obs_hadowplay_is_capture_source_hooked(source)) {
 		*active_game_capture = obs_source_get_ref(source);
 	}
+}
+
+bool obs_hadowplay_get_captured_name(std::string &target_name)
+{
+	obs_source_t *scene_source = obs_frontend_get_current_scene();
+
+	obs_source_t *active_capture_source = nullptr;
+
+	obs_source_enum_active_tree(
+		scene_source, &obs_hadowplay_enum_source_for_hooked_capture,
+		&active_capture_source);
+
+	if (active_capture_source != nullptr) {
+		obs_log(LOG_INFO, "Active capture found: %s",
+			obs_source_get_name(active_capture_source));
+
+		obs_hadowplay_get_product_name_from_source(
+			active_capture_source, target_name);
+		obs_source_release(active_capture_source);
+		obs_source_release(scene_source);
+		return true;
+	}
+
+	obs_source_release(scene_source);
+
+	return false;
 }
 
 bool obs_hadowplay_is_replay_controlled = false;
 bool obs_hadowplay_manual_start = false;
 bool obs_hadowplay_manual_stop = false;
-bool obs_hadowplay_update_thread_running = false;
-bool obs_hadowplay_update_thread_closed = false;
 
-extern "C" bool
-obs_hadowplay_get_fullscreen_window_name(struct dstr *process_name);
+void obs_hadowplay_move_output_file(const std::string &original_filepath,
+				    const std::string &target_name)
+{
+	const size_t filename_pos = original_filepath.find_last_of("/\\") + 1;
 
-pthread_t update_thread;
-struct dstr replay_target_name = {0};
-struct dstr recording_target_name = {0};
+	std::string replay_filename = original_filepath.substr(filename_pos);
+
+	std::string target_directory =
+		original_filepath.substr(0, filename_pos) + target_name;
+
+	if (os_file_exists(target_directory.c_str()) == false) {
+		obs_log(LOG_INFO, "Creating directory: %s",
+			target_directory.c_str());
+		os_mkdir(target_directory.c_str());
+	}
+
+	std::string new_filepath = target_directory + "/" + replay_filename;
+
+	obs_log(LOG_INFO, "Renaming files: %s -> %s", original_filepath.c_str(),
+		new_filepath.c_str());
+	os_rename(original_filepath.c_str(), new_filepath.c_str());
+
+	static std::string title = "Replay Saved";
+
+	if (Config::Inst().m_play_notif_sound == true) {
+		obs_hadowplay_play_notif_sound();
+	}
+	if (Config::Inst().m_show_desktop_notif == true) {
+		obs_hadowplay_show_notification(title, new_filepath);
+	}
+}
+
+bool obs_hadowplay_start_automatic_replay_buffer()
+{
+	// False if auto replay disabled
+	if (Config::Inst().m_auto_replay_buffer == false)
+		return false;
+
+	// False if replay buffer is disabled
+	obs_output_t *replay_output = obs_frontend_get_replay_buffer_output();
+	if (replay_output == nullptr)
+		return false;
+
+	obs_output_release(replay_output);
+
+	// False if already running
+	if (obs_frontend_replay_buffer_active() == true)
+		return false;
+
+	// False if manually stopped
+	if (os_atomic_load_bool(&obs_hadowplay_manual_stop) == true)
+		return false;
+
+	obs_log(LOG_INFO, "Automatic replay started");
+
+	os_atomic_store_bool(&obs_hadowplay_is_replay_controlled, true);
+	obs_frontend_replay_buffer_start();
+
+	return true;
+}
+
+bool obs_hadowplay_stop_automatic_replay_buffer()
+{
+	// False if not running
+	if (obs_frontend_replay_buffer_active() == false)
+		return false;
+
+	// False if manually started
+	if (os_atomic_load_bool(&obs_hadowplay_manual_start) == true)
+		return false;
+
+	obs_log(LOG_INFO, "Automatic replay stopped");
+
+	os_atomic_store_bool(&obs_hadowplay_is_replay_controlled, false);
+	obs_frontend_replay_buffer_stop();
+
+	return true;
+}
 
 extern void obs_hadowplay_replay_buffer_stop()
 {
-	os_atomic_store_bool(&obs_hadowplay_manual_start, false);
-	os_atomic_store_bool(&obs_hadowplay_manual_stop, false);
-
-	if (os_atomic_load_bool(&obs_hadowplay_is_replay_controlled) == true &&
-	    obs_frontend_replay_buffer_active() == true) {
-		os_atomic_store_bool(&obs_hadowplay_is_replay_controlled,
-				     false);
-		obs_frontend_replay_buffer_stop();
-	}
+	obs_hadowplay_stop_automatic_replay_buffer();
 }
+
+bool obs_hadowplay_has_active_captures()
+{
+	obs_source_t *scene_source = obs_frontend_get_current_scene();
+
+	obs_source_t *hooked_capture_source = nullptr;
+
+	obs_source_enum_active_tree(
+		scene_source, obs_hadowplay_enum_source_for_hooked_capture,
+		&hooked_capture_source);
+
+	bool has_active_capture = hooked_capture_source != nullptr;
+
+	obs_source_release(hooked_capture_source);
+	obs_source_release(scene_source);
+
+	return has_active_capture;
+}
+
+bool obs_hadowplay_refresh_automatic_replay_buffer()
+{
+	// Early out if auto replay disabled
+	if (Config::Inst().m_auto_replay_buffer == false)
+		return false;
+
+	// Early out if replay buffer disabled
+	obs_output_t *replay_output = obs_frontend_get_replay_buffer_output();
+	if (replay_output == nullptr)
+		return false;
+	obs_output_release(replay_output);
+
+	return obs_hadowplay_has_active_captures();
+}
+
+#pragma region Update Thread
+
+bool obs_hadowplay_update_thread_running = false;
+bool obs_hadowplay_update_thread_closed = false;
+
+pthread_t update_thread;
 
 void *obs_hadowplay_update(void *param)
 {
@@ -109,98 +244,26 @@ void *obs_hadowplay_update(void *param)
 	snprintf(thread_name, 64, "%s update thread", PLUGIN_NAME);
 	os_set_thread_name(thread_name);
 
+	os_atomic_store_bool(&obs_hadowplay_update_thread_running, true);
+
 	while (os_atomic_load_bool(&obs_hadowplay_update_thread_running) ==
 	       true) {
 
-		if (Config::Inst().m_auto_replay_buffer == true) {
-
-			obs_output_t *replay_output =
-				obs_frontend_get_replay_buffer_output();
-
-			if (replay_output != NULL &&
-			    os_atomic_load_bool(&obs_hadowplay_manual_start) ==
-				    false) {
-				obs_output_release(replay_output);
-
-				obs_source_t *scene_source =
-					obs_frontend_get_current_scene();
-
-				obs_source_t *hooked_capture_source = NULL;
-
-				obs_source_enum_active_tree(
-					scene_source,
-					obs_hadowplay_enum_source_for_hooked_capture,
-					&hooked_capture_source);
-
-				if (hooked_capture_source != NULL) {
-					if (obs_frontend_replay_buffer_active() ==
-						    false &&
-					    os_atomic_load_bool(
-						    &obs_hadowplay_manual_stop) ==
-						    false &&
-					    obs_hadowplay_get_fullscreen_window_name(
-						    NULL) == true) {
-						const char *source_name =
-							obs_source_get_name(
-								hooked_capture_source);
-						obs_log(LOG_INFO,
-							"Active game capture found: %s",
-							source_name);
-						os_atomic_store_bool(
-							&obs_hadowplay_is_replay_controlled,
-							true);
-						obs_frontend_replay_buffer_start();
-						obs_log(LOG_INFO,
-							"Replay buffer started");
-					}
-
-					obs_source_release(hooked_capture_source);
-				} else if (os_atomic_load_bool(
-						   &obs_hadowplay_is_replay_controlled) ==
-						   true &&
-					   obs_frontend_replay_buffer_active() ==
-						   true) {
-					obs_log(LOG_INFO,
-						"No active game capture found");
-					obs_frontend_replay_buffer_stop();
-					obs_log(LOG_INFO,
-						"Replay buffer stopped");
-
-					os_atomic_store_bool(
-						&obs_hadowplay_is_replay_controlled,
-						false);
-				} else if (obs_frontend_replay_buffer_active() ==
-					   false) {
-					os_atomic_store_bool(
-						&obs_hadowplay_manual_stop,
-						false);
-				}
-
-				obs_source_release(scene_source);
+		if (obs_hadowplay_refresh_automatic_replay_buffer() == true) {
+			if (obs_hadowplay_start_automatic_replay_buffer() ==
+			    true) {
+				obs_log(LOG_INFO,
+					"Started automatic replay buffer");
 			}
-
-			if (obs_frontend_replay_buffer_active() == true &&
-			    dstr_is_empty(&replay_target_name)) {
-				if (obs_hadowplay_get_fullscreen_window_name(
-					    &replay_target_name) == true) {
-					obs_log(LOG_INFO,
-						"Replay target found: %s",
-						replay_target_name.array);
-				}
+		} else {
+			if (obs_hadowplay_stop_automatic_replay_buffer() ==
+			    true) {
+				obs_log(LOG_INFO,
+					"Stopped automatic replay buffer");
 			}
-
-			if (obs_frontend_recording_active() == true &&
-			    dstr_is_empty(&recording_target_name)) {
-				if (obs_hadowplay_get_fullscreen_window_name(
-					    &recording_target_name) == true) {
-					obs_log(LOG_INFO,
-						"Recording target found: %s",
-						recording_target_name.array);
-				}
-			}
-
-			os_sleep_ms(1000);
 		}
+
+		os_sleep_ms(1000);
 	}
 
 	obs_hadowplay_replay_buffer_stop();
@@ -210,49 +273,15 @@ void *obs_hadowplay_update(void *param)
 	return 0;
 }
 
-void obs_hadowplay_move_output_file(struct dstr *original_filepath,
-				    struct dstr *target_name)
+void obs_hadowplay_initialise_update_thread()
 {
-	const char *dir_start = strrchr(original_filepath->array, '/');
-
-	struct dstr replay_filename;
-	dstr_init_copy(&replay_filename, dir_start + 1);
-
-	struct dstr file_dir;
-	dstr_init(&file_dir);
-
-	dstr_ncopy_dstr(&file_dir, original_filepath,
-			(dir_start + 1) - original_filepath->array);
-
-	dstr_cat_dstr(&file_dir, target_name);
-	dstr_cat(&file_dir, "/");
-
-	if (os_file_exists(file_dir.array) == false) {
-		obs_log(LOG_INFO, "Creating directory: %s", file_dir.array);
-		os_mkdir(file_dir.array);
+	int result = pthread_create(&update_thread, NULL, obs_hadowplay_update,
+				    NULL);
+	if (result != 0) {
+		obs_log(LOG_ERROR,
+			"Failed to create update thread (code %d), plugin is no longer able to track when to toggle the replay buffer",
+			result);
 	}
-
-	struct dstr new_filepath;
-	dstr_init_copy_dstr(&new_filepath, &file_dir);
-	dstr_cat_dstr(&new_filepath, &replay_filename);
-
-	obs_log(LOG_INFO, "Renaming files: %s -> %s", original_filepath->array,
-		new_filepath.array);
-	os_rename(original_filepath->array, new_filepath.array);
-
-	struct dstr title;
-	dstr_init_copy(&title, "Replay Saved");
-
-	if (Config::Inst().m_play_notif_sound == true) {
-		obs_hadowplay_play_notif_sound();
-	}
-	if (Config::Inst().m_show_desktop_notif == true) {
-		obs_hadowplay_show_notification(&title, &new_filepath);
-	}
-
-	dstr_free(&replay_filename);
-	dstr_free(&file_dir);
-	dstr_free(&new_filepath);
 }
 
 bool obs_hadowplay_close_update_thread()
@@ -276,50 +305,7 @@ bool obs_hadowplay_close_update_thread()
 	return true;
 }
 
-bool obs_hadowplay_start_automatic_replay_buffer()
-{
-	// False if already running
-	if (obs_frontend_replay_buffer_active() == true)
-		return false;
-
-	// False if manually stopped
-	if (obs_hadowplay_manual_stop == true)
-		return false;
-
-	obs_hadowplay_is_replay_controlled = true;
-	obs_frontend_replay_buffer_start();
-
-	return true;
-}
-
-bool obs_hadowplay_stop_automatic_replay_buffer()
-{
-	// False if not running
-	if (obs_frontend_replay_buffer_active() == false)
-		return false;
-
-	// False if manually started
-	if (obs_hadowplay_manual_start == true)
-		return false;
-
-	obs_hadowplay_is_replay_controlled = false;
-	obs_frontend_replay_buffer_stop();
-
-	return true;
-}
-
-bool obs_hadowplay_has_active_captures()
-{
-	obs_source_t *scene_source = obs_frontend_get_current_scene();
-
-	obs_source_t *hooked_capture_source = nullptr;
-
-	obs_source_enum_active_tree(
-		scene_source, obs_hadowplay_enum_source_for_hooked_capture,
-		&hooked_capture_source);
-
-	return hooked_capture_source != nullptr;
-}
+#pragma endregion
 
 #pragma region Hooked/UnHooked signals
 
@@ -333,12 +319,10 @@ void obs_hadowplay_win_capture_hooked(void *data, calldata_t *calldata)
 	const char *win_class = calldata_string(calldata, "class");
 	const char *exe = calldata_string(calldata, "executable");
 
-	obs_log(LOG_INFO, "Capture hooked %s", obs_source_get_name(source));
+	if (exe == nullptr)
+		return;
 
-	if (obs_hadowplay_is_exe_excluded(exe) == false)
-	{
-		obs_hadowplay_start_automatic_replay_buffer();
-	}
+	// TODO
 }
 
 void obs_hadowplay_win_capture_unhooked(void *data, calldata_t *calldata)
@@ -348,12 +332,7 @@ void obs_hadowplay_win_capture_unhooked(void *data, calldata_t *calldata)
 
 	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
 
-	obs_log(LOG_INFO, "Capture unhooked %s", obs_source_get_name(source));
-
-	if (obs_hadowplay_has_active_captures() == false)
-	{
-		obs_hadowplay_stop_automatic_replay_buffer();
-	}
+	// TODO
 }
 
 #pragma endregion
@@ -367,8 +346,6 @@ void obs_hadowplay_source_activated(void *data, calldata_t *calldata)
 
 	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
 
-	obs_log(LOG_INFO, "Source activated %s", obs_source_get_name(source));
-
 	if (obs_hadowplay_is_capture_source(source)) {
 		signal_handler_t *source_signal_handler =
 			obs_source_get_signal_handler(source);
@@ -376,15 +353,8 @@ void obs_hadowplay_source_activated(void *data, calldata_t *calldata)
 				       &obs_hadowplay_win_capture_hooked,
 				       nullptr);
 		signal_handler_connect(source_signal_handler, "unhooked",
-				       &obs_hadowplay_win_capture_hooked,
+				       &obs_hadowplay_win_capture_unhooked,
 				       nullptr);
-
-		obs_log(LOG_INFO, "Source connected %s", obs_source_get_name(source));
-
-		if (obs_hadowplay_has_active_captures())
-		{
-			obs_hadowplay_start_automatic_replay_buffer();
-		}
 	}
 }
 
@@ -395,8 +365,6 @@ void obs_hadowplay_source_deactivated(void *data, calldata_t *calldata)
 
 	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
 
-	obs_log(LOG_INFO, "Source deactivated %s", obs_source_get_name(source));
-
 	if (obs_hadowplay_is_capture_source(source)) {
 		signal_handler_t *source_signal_handler =
 			obs_source_get_signal_handler(source);
@@ -404,7 +372,7 @@ void obs_hadowplay_source_deactivated(void *data, calldata_t *calldata)
 					  &obs_hadowplay_win_capture_hooked,
 					  nullptr);
 		signal_handler_disconnect(source_signal_handler, "unhooked",
-					  &obs_hadowplay_win_capture_hooked,
+					  &obs_hadowplay_win_capture_unhooked,
 					  nullptr);
 	}
 }
@@ -418,9 +386,9 @@ void obs_hadowplay_initialise()
 			       &obs_hadowplay_source_activated, nullptr);
 	signal_handler_connect(signal_handler, "source_deactivate",
 			       &obs_hadowplay_source_deactivated, nullptr);
-
-	obs_log(LOG_INFO, "Sources connected");
 }
+
+std::string recording_target_name;
 
 void obs_hadowplay_frontend_event_callback(enum obs_frontend_event event,
 					   void *private_data)
@@ -429,14 +397,7 @@ void obs_hadowplay_frontend_event_callback(enum obs_frontend_event event,
 
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING: {
-		break;
-		int result = pthread_create(&update_thread, NULL,
-					    obs_hadowplay_update, NULL);
-		if (result != 0) {
-			obs_log(LOG_ERROR,
-				"Failed to create update thread (code %d), plugin is no longer able to track when to toggle the replay buffer",
-				result);
-		}
+		obs_hadowplay_initialise_update_thread();
 		break;
 	}
 
@@ -459,68 +420,54 @@ void obs_hadowplay_frontend_event_callback(enum obs_frontend_event event,
 		    false) {
 			os_atomic_store_bool(&obs_hadowplay_manual_start, true);
 		}
-
-		dstr_init(&replay_target_name);
-		if (obs_hadowplay_get_fullscreen_window_name(
-			    &replay_target_name) == true) {
-			obs_log(LOG_INFO, "Replay target found: %s",
-				replay_target_name.array);
-		}
 		break;
 	}
 
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED: {
-		if (dstr_is_empty(&replay_target_name) == true) {
-			if (obs_hadowplay_get_fullscreen_window_name(
-				    &replay_target_name) == true) {
-				obs_log(LOG_INFO, "Replay target found: %s",
-					replay_target_name.array);
-			}
-		}
-
-		if (dstr_is_empty(&replay_target_name) == true) {
-			return;
-		}
-
 		const char *replay_path_c = obs_frontend_get_last_replay();
 
 		if (replay_path_c == NULL) {
 			return;
 		}
 
-		struct dstr replay_path;
-		dstr_init_copy(&replay_path, replay_path_c);
+		std::string target_name;
+		if (obs_hadowplay_get_captured_name(target_name) == true) {
 
-		obs_hadowplay_move_output_file(&replay_path,
-					       &replay_target_name);
-
-		dstr_free(&replay_path);
+			obs_hadowplay_move_output_file(replay_path_c,
+						       target_name);
+		}
 		break;
 	}
-#pragma endregion Replay buffer events
+#pragma endregion
 
 #pragma region Recording events
 	case OBS_FRONTEND_EVENT_RECORDING_STARTED: {
 		// Reset recording name for fresh recordings
-		dstr_init(&recording_target_name);
-		if (obs_hadowplay_get_fullscreen_window_name(
-			    &recording_target_name) == true) {
+		recording_target_name.clear();
+		std::string target_name;
+
+		if (obs_hadowplay_get_captured_name(target_name) == true) {
+			recording_target_name = target_name;
 			obs_log(LOG_INFO, "Recording target found: %s",
-				recording_target_name.array);
+				recording_target_name.c_str());
 		}
 		break;
 	}
 
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPED: {
-		if (dstr_is_empty(&recording_target_name) == true) {
-			if (obs_hadowplay_get_fullscreen_window_name(
-				    &recording_target_name) == true) {
+
+		if (recording_target_name.empty() == true) {
+			std::string target_name;
+
+			if (obs_hadowplay_get_captured_name(target_name) ==
+			    true) {
+				recording_target_name = target_name;
 				obs_log(LOG_INFO, "Recording target found: %s",
-					recording_target_name.array);
+					recording_target_name.c_str());
 			}
 		}
 
-		if (dstr_is_empty(&recording_target_name) == true) {
+		if (recording_target_name.empty() == true) {
 			return;
 		}
 
@@ -531,19 +478,13 @@ void obs_hadowplay_frontend_event_callback(enum obs_frontend_event event,
 			return;
 		}
 
-		struct dstr recording_path;
-		dstr_init_copy(&recording_path, recording_path_c);
-
-		obs_hadowplay_move_output_file(&recording_path,
-					       &recording_target_name);
-
-		dstr_free(&recording_path);
+		obs_hadowplay_move_output_file(recording_path_c,
+					       recording_target_name);
 		break;
 	}
+#pragma endregion
 
-#pragma endregion Recording events
 	case OBS_FRONTEND_EVENT_EXIT: {
-		break;
 		obs_hadowplay_close_update_thread();
 		break;
 	}
@@ -580,9 +521,6 @@ void obs_hadowplay_show_settings_dialog(void *data)
 
 bool obs_module_load(void)
 {
-	// No need to be atomic since the thread hasn't started yet.
-	obs_hadowplay_update_thread_running = true;
-
 	obs_hadowplay_initialise();
 
 	obs_frontend_add_event_callback(obs_hadowplay_frontend_event_callback,
@@ -609,7 +547,7 @@ bool obs_module_load(void)
 void obs_module_unload()
 {
 	// Make sure the update thread has closed
-	// obs_hadowplay_close_update_thread();
+	obs_hadowplay_close_update_thread();
 
 	obs_log(LOG_INFO, "plugin unloaded");
 }

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -118,6 +118,33 @@ void *obs_hadowplay_update(void *param)
 					&game_capture_source);
 
 				if (game_capture_source != NULL) {
+					proc_handler_t *proc_handler =
+						obs_source_get_proc_handler(
+							game_capture_source);
+
+					calldata_t calldata;
+
+					calldata_init(&calldata);
+
+					proc_handler_call(proc_handler,
+							  "get_hooked",
+							  &calldata);
+
+					const char *title = calldata_string(
+						&calldata, "title");
+					const char *cls = calldata_string(
+						&calldata, "class");
+					const char *exe = calldata_string(
+						&calldata, "executable");
+
+					void *window =
+						obs_hadoowplay_print_window(
+							cls);
+
+					obs_log(LOG_INFO,
+						"game-capture info: %s %s %s %p",
+						title, cls, exe, window);
+
 					if (obs_frontend_replay_buffer_active() ==
 						    false &&
 					    os_atomic_load_bool(

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -175,6 +175,9 @@ bool obs_hadowplay_start_automatic_replay_buffer()
 
 bool obs_hadowplay_stop_automatic_replay_buffer()
 {
+	// Clear manual stop if automatic stop is called
+	os_atomic_store_bool(&obs_hadowplay_manual_stop, false);
+
 	// False if not running
 	if (obs_frontend_replay_buffer_active() == false)
 		return false;

--- a/src/plugin-platform-helpers.cpp
+++ b/src/plugin-platform-helpers.cpp
@@ -1,23 +1,5 @@
 #include "plugin-platform-helpers.hpp"
 
-bool dstr_get_filename(struct dstr *filepath, struct dstr *filename)
-{
-	const char *filename_start = strrchr(filepath->array, '\\') + 1;
-
-	const char *filename_end = strrchr(filename_start, '.');
-
-	if (filename_start != NULL && filename_end != NULL) {
-		size_t start = (filename_start - filepath->array);
-		size_t count = (filename_end - filename_start);
-
-		dstr_mid(filename, filepath, start, count);
-	} else {
-		return false;
-	}
-
-	return true;
-}
-
 #include <QString>
 #include <obs-module.h>
 
@@ -38,14 +20,14 @@ struct SystemTrayNotification {
 	QString message;
 };
 
-bool obs_hadowplay_show_notification(struct dstr *title, struct dstr *message)
+bool obs_hadowplay_show_notification(std::string &title, std::string &message)
 {
 	if (!QSystemTrayIcon::isSystemTrayAvailable() ||
 	    !QSystemTrayIcon::supportsMessages())
 		return false;
 
 	SystemTrayNotification *notification = new SystemTrayNotification{
-		QString(title->array), QString(message->array)};
+		QString(title.c_str()), QString(message.c_str())};
 
 	obs_queue_task(
 		OBS_TASK_UI,

--- a/src/plugin-platform-helpers.hpp
+++ b/src/plugin-platform-helpers.hpp
@@ -10,7 +10,8 @@
 #define EXTERNC
 #endif
 
-std::string obs_hadowplay_strip_executable_extension(const std::string &filename);
+std::string
+obs_hadowplay_strip_executable_extension(const std::string &filename);
 
 EXTERNC void obs_hadowplay_play_notif_sound();
 

--- a/src/plugin-platform-helpers.hpp
+++ b/src/plugin-platform-helpers.hpp
@@ -10,6 +10,8 @@
 #define EXTERNC
 #endif
 
+std::string obs_hadowplay_strip_executable_extension(const std::string &filename);
+
 EXTERNC void obs_hadowplay_play_notif_sound();
 
 EXTERNC bool obs_hadowplay_is_exe_excluded(const char *exe);

--- a/src/plugin-platform-helpers.hpp
+++ b/src/plugin-platform-helpers.hpp
@@ -12,5 +12,7 @@ EXTERNC bool dstr_get_filename(struct dstr *filepath, struct dstr *filename);
 
 EXTERNC void obs_hadowplay_play_notif_sound();
 
+EXTERNC void *obs_hadoowplay_print_window(const char *cls);
+
 EXTERNC bool obs_hadowplay_show_notification(struct dstr *title,
 					     struct dstr *message);

--- a/src/plugin-platform-helpers.hpp
+++ b/src/plugin-platform-helpers.hpp
@@ -12,7 +12,7 @@ EXTERNC bool dstr_get_filename(struct dstr *filepath, struct dstr *filename);
 
 EXTERNC void obs_hadowplay_play_notif_sound();
 
-EXTERNC void *obs_hadoowplay_print_window(const char *cls);
+EXTERNC bool obs_hadowplay_is_exe_excluded(const char *exe);
 
 EXTERNC bool obs_hadowplay_show_notification(struct dstr *title,
 					     struct dstr *message);

--- a/src/plugin-platform-helpers.hpp
+++ b/src/plugin-platform-helpers.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <obs.h>
 #include <util/dstr.h>
+#include <string>
 
 #ifdef __cplusplus
 #define EXTERNC extern "C"
@@ -8,11 +10,13 @@
 #define EXTERNC
 #endif
 
-EXTERNC bool dstr_get_filename(struct dstr *filepath, struct dstr *filename);
-
 EXTERNC void obs_hadowplay_play_notif_sound();
 
 EXTERNC bool obs_hadowplay_is_exe_excluded(const char *exe);
 
-EXTERNC bool obs_hadowplay_show_notification(struct dstr *title,
-					     struct dstr *message);
+EXTERNC bool obs_hadowplay_show_notification(std::string &title,
+					     std::string &message);
+
+EXTERNC bool
+obs_hadowplay_get_product_name_from_source(obs_source_t *source,
+					   std::string &product_name);

--- a/src/plugin-windows.cpp
+++ b/src/plugin-windows.cpp
@@ -150,6 +150,16 @@ bool win_get_window_filepath(HWND window, std::wstring &process_filepath)
 	return true;
 }
 
+std::string obs_hadowplay_strip_executable_extension(const std::string &filename)
+{
+	const char *ext = os_get_path_extension(filename.c_str());
+	if (ext != nullptr && strcmpi(ext, ".exe") == 0)
+	{
+		return filename.substr(0, ext - filename.c_str());
+	}
+	return filename;
+}
+
 bool obs_hadowplay_get_product_name_from_source(obs_source_t *source,
 						std::string &product_name)
 {
@@ -176,15 +186,18 @@ bool obs_hadowplay_get_product_name_from_source(obs_source_t *source,
 
 	bfree(win_class_w);
 
-	calldata_free(&hooked_calldata);
-
 	std::wstring filepath;
 
 	if (win_get_window_filepath(window, filepath) == true) {
 		if (win_get_product_name(filepath, product_name) == true) {
+			calldata_free(&hooked_calldata);
 			return true;
 		}
 	}
+
+	product_name = obs_hadowplay_strip_executable_extension(calldata_string(&hooked_calldata, "executable"));
+
+	calldata_free(&hooked_calldata);
 
 	return false;
 }
@@ -194,18 +207,10 @@ bool obs_hadowplay_is_exe_excluded(const char *exe)
 	if (exe == nullptr)
 		return true;
 
-	std::string exe_str = exe;
-
-	size_t dot_pos = exe_str.find_last_of('.');
-
-	// Truncate ".exe"
-	if (dot_pos != std::string::npos &&
-	    exe_str.compare(dot_pos, exe_str.size() - dot_pos, ".exe") == 0) {
-		exe_str = exe_str.substr(0, exe_str.size() - 4);
-	}
+	std::string exe_str = obs_hadowplay_strip_executable_extension(exe);
 
 	for (std::string val : Config::Inst().m_exclusions) {
-		if (strcmpi(val.data(), exe_str.data()) == 0) {
+		if (strcmpi(val.c_str(), exe_str.c_str()) == 0) {
 			return true;
 		}
 	}

--- a/src/plugin-windows.cpp
+++ b/src/plugin-windows.cpp
@@ -20,6 +20,13 @@ void obs_hadowplay_play_sound(const wchar_t *filepath)
 	PlaySound(filepath, NULL, SND_FILENAME | SND_ASYNC);
 }
 
+void *obs_hadoowplay_print_window(const char *cls)
+{
+	HWND window = FindWindowA(cls, nullptr);
+
+	return (void *)window;
+}
+
 bool win_get_product_name(const struct dstr *filepath,
 			  struct dstr *product_name)
 {

--- a/src/plugin-windows.cpp
+++ b/src/plugin-windows.cpp
@@ -150,11 +150,11 @@ bool win_get_window_filepath(HWND window, std::wstring &process_filepath)
 	return true;
 }
 
-std::string obs_hadowplay_strip_executable_extension(const std::string &filename)
+std::string
+obs_hadowplay_strip_executable_extension(const std::string &filename)
 {
 	const char *ext = os_get_path_extension(filename.c_str());
-	if (ext != nullptr && strcmpi(ext, ".exe") == 0)
-	{
+	if (ext != nullptr && strcmpi(ext, ".exe") == 0) {
 		return filename.substr(0, ext - filename.c_str());
 	}
 	return filename;
@@ -195,7 +195,8 @@ bool obs_hadowplay_get_product_name_from_source(obs_source_t *source,
 		}
 	}
 
-	product_name = obs_hadowplay_strip_executable_extension(calldata_string(&hooked_calldata, "executable"));
+	product_name = obs_hadowplay_strip_executable_extension(
+		calldata_string(&hooked_calldata, "executable"));
 
 	calldata_free(&hooked_calldata);
 

--- a/src/plugin-windows.cpp
+++ b/src/plugin-windows.cpp
@@ -169,7 +169,12 @@ bool obs_hadowplay_get_product_name_from_source(obs_source_t *source,
 
 	const char *win_class = calldata_string(&hooked_calldata, "class");
 
-	HWND window = FindWindowA(win_class, nullptr);
+	wchar_t *win_class_w = nullptr;
+	os_utf8_to_wcs_ptr(win_class, strlen(win_class), &win_class_w);
+
+	HWND window = FindWindowW(win_class_w, nullptr);
+
+	bfree(win_class_w);
 
 	calldata_free(&hooked_calldata);
 

--- a/src/ui/SettingsDialog.cpp
+++ b/src/ui/SettingsDialog.cpp
@@ -6,6 +6,7 @@
 
 #include <util/config-file.h>
 #include "plugin-support.h"
+#include "plugin-platform-helpers.hpp"
 #include "config/config.hpp"
 
 SettingsDialog::SettingsDialog() : QDialog(nullptr), ui(new Ui::SettingsDialog)
@@ -70,8 +71,7 @@ void SettingsDialog::ApplyConfig()
 	Config::Inst().m_exclusions.clear();
 	for (int i = 0; i < count; ++i) {
 		auto item = this->ui->exceptions_list->item(i);
-		Config::Inst().m_exclusions.push_back(
-			item->text().toStdString().c_str());
+		Config::Inst().m_exclusions.push_back(obs_hadowplay_strip_executable_extension(item->text().toStdString()));
 	}
 
 	obs_hadowplay_replay_buffer_stop();

--- a/src/ui/SettingsDialog.cpp
+++ b/src/ui/SettingsDialog.cpp
@@ -76,7 +76,9 @@ void SettingsDialog::ApplyConfig()
 	Config::Inst().m_exclusions.clear();
 	for (int i = 0; i < count; ++i) {
 		auto item = this->ui->exceptions_list->item(i);
-		Config::Inst().m_exclusions.push_back(obs_hadowplay_strip_executable_extension(item->text().toStdString()));
+		Config::Inst().m_exclusions.push_back(
+			obs_hadowplay_strip_executable_extension(
+				item->text().toStdString()));
 	}
 
 	obs_hadowplay_replay_buffer_stop();


### PR DESCRIPTION
Re-write a large chunk of the window query code to instead use the `get_hooked` procedure to always fetch the captured process name.

This also means this plugin now works with window-caputre and game-capture with either hotkey/specific window settings!